### PR TITLE
Also check /Run on other modifications

### DIFF
--- a/tests/Wikipedia/ApiTest.php
+++ b/tests/Wikipedia/ApiTest.php
@@ -47,4 +47,12 @@ class ApiTest extends \PHPUnit\Framework\TestCase
         $ret = $api->usercontribs('ClueBot NG');
         $this->assertEquals(50, count($api->usercontribs('ClueBot NG', 50)));
     }
+
+    public function testAllowedToRun()
+    {
+        $api = new Api();
+
+        // We are not logged in, so this is always false
+        $this->assertFalse($api->allowedToRun());
+    }
 }


### PR DESCRIPTION
Currently if the /Run page is negative, we don't edit, but still
rollback.

Apply this to `edit`, `rollback` & `move`, which effectivly makes the
bot read only, then /Run is disabled as expected.